### PR TITLE
Add URL for Ozzy Mandice

### DIFF
--- a/_maps/Downhill/downhill.yaml
+++ b/_maps/Downhill/downhill.yaml
@@ -29,4 +29,5 @@ changelog:
       - Initial Release
 authors:
   - name: Ozzy Mandice
+    url: https://www.youtube.com/channel/UCREPZ9vURGgzjTew5X3GgMw
 ...


### PR DESCRIPTION
Ozzy Mandice is a legend, and this actually isn't even close to being his best map. He released most of his maps on YouTube, so that is the best place to link to. He is also available to speak to on Discord, he is OzzyMandice#8541.