### PR TITLE
Corrected the name of the Forest of Fairies background.

### DIFF
--- a/_data/backgrounds.yml
+++ b/_data/backgrounds.yml
@@ -95,7 +95,7 @@
     domination: facingWorlds_domination_introCity.90
     bankruptcy:
 - background: forestFairies
-  name: Forest Fairies
+  name: Forest of Fairies
   download: https://drive.google.com/uc?export=download&id=102QW9aLpmv8n8GpL5DtHNoe4m_XTqYVx
   mapIcon: forestFairies
   music:


### PR DESCRIPTION
As title. The name in the text and on the site should be `Forest of Fairies`; the filename is only `forestFairies` due to the character limit.