### PR TITLE
Add GHA workflow to upload maps to S3 automatically

### DIFF
--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -29,4 +29,4 @@ jobs:
         run: aws s3 cp --recursive ./_maps/. s3://${{ env.BUCKET_NAME }}/cswt/Maps
 
       - name: Create CloudFront invalidation
-        run: aws cloudfront create-invalidation --distribution-id EK8YW6IUP9MB5 --paths "/cswt/Maps/*"
+        run: aws cloudfront create-invalidation --distribution-id EK8YW6IUP9MB5 --paths /cswt/Maps/*

--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -35,7 +35,9 @@ jobs:
       - name: Upload maps to S3
         working-directory: ./_maps
         run: |
-          aws s3 cp *.zip s3://${{ secrets.S3_BUCKET_NAME }}/cswt/Maps
+          for i in *.zip; do
+            [ aws s3 cp i s3://${{ secrets.S3_BUCKET_NAME }}/cswt/Maps ] || break
+          done
 
       - name: Create CloudFront invalidation
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths /cswt/Maps/*

--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -2,24 +2,31 @@ name: Upload Maps to S3
 on:
   push:
     branches: [ master ]
+
 env:
   BUCKET_NAME : "house.nikkums.io-lo4cd"
   AWS_REGION : "us-east-2"  
+
 permissions:
   id-token: write
   contents: read    # This is required for actions/checkout
+
 jobs:
   UploadMapsToS3:
     runs-on: ubuntu-latest
     steps:
-      - name: Git clone the repository
+      - name: Clone the repo
         uses: actions/checkout@v3
-      - name: configure aws credentials
+
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::632957227412:role/github-actions-deploy-role
           role-session-name: ghamapuploadingrolesession
           aws-region: ${{ env.AWS_REGION }}
-      - name:  Upload maps to S3
-        run: |
-          aws s3 cp --recursive ./_maps/. s3://${{ env.BUCKET_NAME }}/cswt/Maps
+
+      - name: Upload maps to S3
+        run: aws s3 cp --recursive ./_maps/. s3://${{ env.BUCKET_NAME }}/cswt/Maps
+
+      - name: Create CloudFront invalidation
+        run: aws cloudfront create-invalidation --distribution-id EK8YW6IUP9MB5 --paths "/cswt/Maps/*"

--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -1,8 +1,7 @@
 name: Upload Maps to S3
 on:
-  push    
-  # push:
-  #   branches: [ master ]
+  push:
+    branches: [ master ]
 env:
   BUCKET_NAME : "house.nikkums.io-lo4cd"
   AWS_REGION : "us-east-2"  

--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -1,8 +1,7 @@
 name: Upload Maps to S3
 on:
-  push
-  # push:
-  #   branches: [ master ]
+  push:
+    branches: [ master ]
 
 permissions:
   id-token: write

--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -1,7 +1,8 @@
 name: Upload Maps to S3
 on:
   push:
-#    branches: [ master ]
+    branches:
+      - master
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -3,7 +3,7 @@ on:
   push:
 #    branches: [ master ]
   workflow_dispatch:
-#
+
 permissions:
   id-token: write
   contents: read    # This is required for actions/checkout

--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -33,7 +33,7 @@ jobs:
           done
 
       - name: Upload maps to S3
-        run: aws s3 cp ./_maps s3://${{ secrets.S3_BUCKET_NAME }}/cswt/Maps --exclude "*" --include "*.zip"
+        run: aws s3 cp ./_maps s3://${{ secrets.S3_BUCKET_NAME }}/cswt/Maps --recursive --exclude "*" --include "*.zip"
 
       - name: Create CloudFront invalidation
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths /cswt/Maps/*

--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -23,4 +23,4 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
       - name:  Upload maps to S3
         run: |
-          aws s3 cp ./_maps/* s3://${{ env.BUCKET_NAME }}/cswt/Maps
+          aws s3 cp --recursive ./_maps/. s3://${{ env.BUCKET_NAME }}/cswt/Maps

--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -1,11 +1,8 @@
 name: Upload Maps to S3
 on:
-  push:
-    branches: [ master ]
-
-env:
-  BUCKET_NAME : "house.nikkums.io-lo4cd"
-  AWS_REGION : "us-east-2"  
+  push
+  # push:
+  #   branches: [ master ]
 
 permissions:
   id-token: write
@@ -21,12 +18,12 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::632957227412:role/github-actions-deploy-role
+          role-to-assume: ${{ secrets.ASSUME_ROLE_ARN }}
           role-session-name: ghamapuploadingrolesession
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Upload maps to S3
-        run: aws s3 cp --recursive ./_maps/. s3://${{ env.BUCKET_NAME }}/cswt/Maps
+        run: aws s3 cp --recursive ./_maps/. s3://${{ secrets.S3_BUCKET_NAME }}/cswt/Maps
 
       - name: Create CloudFront invalidation
-        run: aws cloudfront create-invalidation --distribution-id EK8YW6IUP9MB5 --paths /cswt/Maps/*
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths /cswt/Maps/*

--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -33,11 +33,7 @@ jobs:
           done
 
       - name: Upload maps to S3
-        working-directory: ./_maps
-        run: |
-          for i in *.zip; do
-            [ aws s3 cp i s3://${{ secrets.S3_BUCKET_NAME }}/cswt/Maps ] || break
-          done
+        run: aws s3 cp ./_maps s3://${{ secrets.S3_BUCKET_NAME }}/cswt/Maps --exclude "*" --include "*.zip"
 
       - name: Create CloudFront invalidation
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths /cswt/Maps/*

--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -1,0 +1,26 @@
+name: Upload Maps to S3
+on:
+  push    
+  # push:
+  #   branches: [ master ]
+env:
+  BUCKET_NAME : "house.nikkums.io-lo4cd"
+  AWS_REGION : "us-east-2"  
+permissions:
+  id-token: write
+  contents: read    # This is required for actions/checkout
+jobs:
+  UploadMapsToS3:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git clone the repository
+        uses: actions/checkout@v3
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::632957227412:role/github-actions-deploy-role
+          role-session-name: ghamapuploadingrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name:  Upload maps to S3
+        run: |
+          aws s3 cp ./_maps/* s3://${{ env.BUCKET_NAME }}/cswt/Maps

--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Upload maps to S3
         working-directory: ./_maps
         run: |
-          aws s3 rm --recursive /cswt/Maps/*
           aws s3 cp *.zip s3://${{ secrets.S3_BUCKET_NAME }}/cswt/Maps
 
       - name: Create CloudFront invalidation

--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -1,7 +1,7 @@
 name: Upload Maps to S3
 on:
   push:
-    branches: [ master ]
+#    branches: [ master ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -3,7 +3,7 @@ on:
   push:
 #    branches: [ master ]
   workflow_dispatch:
-
+#
 permissions:
   id-token: write
   contents: read    # This is required for actions/checkout

--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -2,6 +2,7 @@ name: Upload Maps to S3
 on:
   push:
     branches: [ master ]
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -20,9 +21,22 @@ jobs:
           role-to-assume: ${{ secrets.ASSUME_ROLE_ARN }}
           role-session-name: ghamapuploadingrolesession
           aws-region: ${{ secrets.AWS_REGION }}
+      
+      - name: Zip maps
+        shell: bash
+        working-directory: ./_maps
+        run: |
+          for mapDir in *; do
+            cd ${mapDir}
+            zip -r ../${mapDir}.zip .
+            cd ..
+          done
 
       - name: Upload maps to S3
-        run: aws s3 cp --recursive ./_maps/. s3://${{ secrets.S3_BUCKET_NAME }}/cswt/Maps
+        working-directory: ./_maps
+        run: |
+          aws s3 rm --recursive /cswt/Maps/*
+          aws s3 cp *.zip s3://${{ secrets.S3_BUCKET_NAME }}/cswt/Maps
 
       - name: Create CloudFront invalidation
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths /cswt/Maps/*


### PR DESCRIPTION
This workflow zips then uploads the contents of the `_maps` folder to the cswt/Maps folder in the S3 bucket, then creates a CloudFront invalidation to ensure the old versions of the updated files are no longer cached. 

Uploaded files can be reached, with the same file structure as the GitHub repo, at `https://nikkums.io/cswt/Maps/*`, which is to say: `https://nikkums.io/cswt/Maps/GoodybagLair.zip` is one such file.

Side note: we should totally update our `master` branch to `main`.