### PR TITLE
Changed references to master branch to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,9 @@ name: Board Validation
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/upload-to-s3.yml
+++ b/.github/workflows/upload-to-s3.yml
@@ -2,7 +2,7 @@ name: Upload Maps to S3
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "yaml.schemas": {
-        "https://raw.githubusercontent.com/FortuneStreetModding/fortunestreetmodding.github.io/master/schema/mapdescriptor.json": ["/_maps/**/*.yaml"],
+        "https://raw.githubusercontent.com/FortuneStreetModding/fortunestreetmodding.github.io/main/schema/mapdescriptor.json": ["/_maps/**/*.yaml"],
     },
     "cmake.configureOnOpen": false
 }

--- a/_includes/renderMapDownloadUrl.liquid
+++ b/_includes/renderMapDownloadUrl.liquid
@@ -10,4 +10,4 @@ Renders:
 
 {%- endcomment -%}
 {%- include getParent.liquid file_path=include.map.path -%}
-{{ "https://github.com/FortuneStreetModding/fortunestreetmodding.github.io/tree/master/" | append: gd_directory_path }}
+{{ "https://github.com/FortuneStreetModding/fortunestreetmodding.github.io/tree/main/" | append: gd_directory_path }}

--- a/index.html
+++ b/index.html
@@ -30,8 +30,8 @@ layout: default
                 CSWT dev-build
               </button>
               <ul class="dropdown-menu" aria-labelledby="btnGroupLatestDrop" style="">
-                <li><a class="dropdown-item" href="https://raw.githubusercontent.com/FortuneStreetModding/CustomStreetWorldTour/master/Setup/setup.bat">Windows</a></li>
-                <li><a class="dropdown-item" href="https://raw.githubusercontent.com/FortuneStreetModding/CustomStreetWorldTour/master/Setup/setup.sh">Mac</a></li>
+                <li><a class="dropdown-item" href="https://raw.githubusercontent.com/FortuneStreetModding/CustomStreetWorldTour/main/Setup/setup.bat">Windows</a></li>
+                <li><a class="dropdown-item" href="https://raw.githubusercontent.com/FortuneStreetModding/CustomStreetWorldTour/main/Setup/setup.sh">Mac</a></li>
               </ul>
             </div>
           <p></p>
@@ -43,7 +43,7 @@ layout: default
         <div class="card-body">
           <p class="card-text">A WIP texture pack containing many HD textures for Boom Street and Fortune Street. Compatible with the base game and Custom Street World Tour.</p>
           <p class="card-text">
-            <a href="https://github.com/FortuneStreetModding/fortunestreetmodding.github.io/blob/master/Fortune%20Street%20HD%20Textures%20Readme.md" class="btn btn-primary my-2" download="setup.bat">Download</a>
+            <a href="https://github.com/FortuneStreetModding/fortunestreetmodding.github.io/blob/main/Fortune%20Street%20HD%20Textures%20Readme.md" class="btn btn-primary my-2" download="setup.bat">Download</a>
             </p><p></p>
         </div>
       </div><div class="card mx-auto" style="max-width:50rem">

--- a/jszipdownload.html
+++ b/jszipdownload.html
@@ -5,7 +5,7 @@
 
 <script>
 
-var fileURLs = ['https://raw.githubusercontent.com/FortuneStreetModding/fortunestreetmodding.github.io/master/_maps/Abwarten/Abwarten.yaml', 'https://raw.githubusercontent.com/FortuneStreetModding/fortunestreetmodding.github.io/master/_maps/Abwarten/Abwarten0.frb'];
+var fileURLs = ['https://raw.githubusercontent.com/FortuneStreetModding/fortunestreetmodding.github.io/main/_maps/Abwarten/Abwarten.yaml', 'https://raw.githubusercontent.com/FortuneStreetModding/fortunestreetmodding.github.io/main/_maps/Abwarten/Abwarten0.frb'];
 var zip = new JSZip();
 var count = 0;
 

--- a/mapHelp.md
+++ b/mapHelp.md
@@ -7,13 +7,13 @@ layout: mapHelp
 
 The maps on this page are hosted on Github. To upload maps you need a Github Account.
 
-To upload a new map you must create a pull request using the branch `master` as base. The pull request must contain the new folder for your map under the path `_maps/MyMap`. Your map folder must not contain any spaces. The folder must contain:
+To upload a new map you must create a pull request using the branch `main` as base. The pull request must contain the new folder for your map under the path `_maps/MyMap`. Your map folder must not contain any spaces. The folder must contain:
 - 1 .yaml file (the map descriptor of your map, must not contain any special symbols)
 - 1-4 .frb files (the board layout files of your map)
 - 1-4 .webp files (the screenshots for each of your board layouts)
 - May contain a .png file for the map icon
 
-You can take a look at one of the other maps like [Facing Worlds](https://github.com/FortuneStreetModding/fortunestreetmodding.github.io/tree/master/_maps/FacingWorlds), [KingOfTheHill](https://github.com/FortuneStreetModding/fortunestreetmodding.github.io/tree/master/_maps/KingOfTheHill) or the other maps in this repository.
+You can take a look at one of the other maps like [Facing Worlds](https://github.com/FortuneStreetModding/fortunestreetmodding.github.io/tree/main/_maps/FacingWorlds), [KingOfTheHill](https://github.com/FortuneStreetModding/fortunestreetmodding.github.io/tree/main/_maps/KingOfTheHill) or the other maps in this repository.
 
 **Please test your map at least one full game before creating a pull request!**
 
@@ -23,7 +23,7 @@ You can take a look at one of the other maps like [Facing Worlds](https://github
 
 ![Export Yaml](images/export_yaml.png)
 
-**(2)** Prepare your map folder. Take a look into one of the other maps like [Facing Worlds](https://github.com/FortuneStreetModding/fortunestreetmodding.github.io/tree/master/_maps/FacingWorlds), [KingOfTheHill](https://github.com/FortuneStreetModding/fortunestreetmodding.github.io/tree/master/_maps/KingOfTheHill) how your map folder must look like.
+**(2)** Prepare your map folder. Take a look into one of the other maps like [Facing Worlds](https://github.com/FortuneStreetModding/fortunestreetmodding.github.io/tree/main/_maps/FacingWorlds), [KingOfTheHill](https://github.com/FortuneStreetModding/fortunestreetmodding.github.io/tree/main/_maps/KingOfTheHill) how your map folder must look like.
 
 ![Directory Structure](images/myMap_directoryStructure.png)
 
@@ -59,11 +59,11 @@ authors:
 
 ![Drag'n'Drop](images/myMap_dragndrop.png)
 
-**(8)** You can now enter a commit description, but you can also leave it as is. Make sure `Commit directly to the master branch` is selected.
+**(8)** You can now enter a commit description, but you can also leave it as is. Make sure `Commit directly to the main branch` is selected.
 
 ![Commit](images/myMap_commit.png)
 
-**(9)** Now Github will tell you that your branch is at least 1 commit ahead of FortuneStreetModding:master. Click on the `Pull Request` link beside it to create a Pull Request.
+**(9)** Now Github will tell you that your branch is at least 1 commit ahead of FortuneStreetModding:main. Click on the `Pull Request` link beside it to create a Pull Request.
 
 ![Commit](images/myMap_createPullRequest.png)
 


### PR DESCRIPTION
Special thanks to `git grep`, this PR changes what should be all of the references to the `master` branch to `main`, to make renaming the branch as easy as possible. From here, the steps to do so are:

1) Rename the branch in the GitHub repo interface
   * Settings > Branches > Edit Pencil icon
2) Merge this PR
3) Redeploy the GitHub Pages site, possibly done automatically via step 2