### PR TITLE
Reset Quad/QuietStreet back to default district names

### DIFF
--- a/_maps/Quad/Quad.yaml
+++ b/_maps/Quad/Quad.yaml
@@ -22,16 +22,6 @@ tourMode:
 music:
   map: winternights.45
   targetMet: primalone.85
-districtNames:
-  en:
-  - Croquedead
-  - Chocbox
-  - Alch
-  - EWIE10
-  - Tokenizer
-  - Landmaster
-  - Lombre
-  - Hemi
 changelog:
   - version: 1
     added: 

--- a/_maps/QuadC/QuadC.yaml
+++ b/_maps/QuadC/QuadC.yaml
@@ -25,16 +25,6 @@ music:
     - https://drive.google.com/u/2/uc?id=1IFpwIYeZEG3P4cukqD6cbrRQnLD8aoCq&export=download&confirm=1
   map: winternights.45
   targetMet: primalone.85
-districtNames:
-  en:
-  - Croquedead
-  - Chocbox
-  - Alch
-  - EWIE10
-  - Tokenizer
-  - Landmaster
-  - Lombre
-  - Hemi
 changelog:
   - version: 1
     added: 

--- a/_maps/QuietStreet/QuietStreet.yaml
+++ b/_maps/QuietStreet/QuietStreet.yaml
@@ -22,19 +22,6 @@ tourMode:
 music:
   map: jazztheme.90
   targetMet: primalone.85
-districtNames:
-  en:
-  - Croquedead
-  - Chocbox
-  - Alch
-  - EWIE10
-  - Tokenizer
-  - Landmaster
-  - Lombre
-  - Hemi
-  - Victor
-  - Gavo
-  - Tytohbird
 changelog:
   - version: 1
     added: 

--- a/_maps/QuietStreetC/QuietStreetC.yaml
+++ b/_maps/QuietStreetC/QuietStreetC.yaml
@@ -25,19 +25,6 @@ music:
     - https://drive.google.com/u/2/uc?id=19za5Z0Neuq1UG-j2IfCk1ZvRJf5hU-z6&export=download
   map: jazztheme.90
   targetMet: primalone.85
-districtNames:
-  en:
-  - Croquedead
-  - Chocbox
-  - Alch
-  - EWIE10
-  - Tokenizer
-  - Landmaster
-  - Lombre
-  - Hemi
-  - Victor
-  - Gavo
-  - Tytohbird
 changelog:
   - version: 1
     added: 


### PR DESCRIPTION
I've kind of lost interest in Bloons TD 6 and unlike the people in our community, most of the people in Bloons TD 6's community weren't all that great anyways.