### PR TITLE
Fix music download links

### DIFF
--- a/_maps/KoopaTycoonTown/KoopaTycoonTown.yaml
+++ b/_maps/KoopaTycoonTown/KoopaTycoonTown.yaml
@@ -14,23 +14,12 @@ frbFile1: koopa_tycoon
 background: bg901fixed
 mapIcon: koopa_tycoon
 music:
-  download: https://nikkums.io/cswt/BGM/KoopaTycoonTown.music.zip
+  download: 
+    - https://nikkums.io/cswt/BGM/KoopaTycoonTown.music.zip
   map: koopa_tycoon.50
-  stock: 
-  ventureCards: 
-  auction: 
-  targetMet: 
-  win: 
-  guestAppear:
-  guestLeave:
-  badVentureCard:
-  takeAbreak:
   promotionMii: tycoon_promotion.50
   promotionMario: tycoon_promotion.50
   promotionDragonQuest: tycoon_promotion.50
-  forcedBuyout:
-  domination:
-  bankruptcy:
 tourMode:
   bankruptcyLimit: 1
   opponent1: Yoshi

--- a/_maps/RainbowRoadWii/RainbowRoadWii.yaml
+++ b/_maps/RainbowRoadWii/RainbowRoadWii.yaml
@@ -16,7 +16,8 @@ frbFile1: rainbowroadmkwii
 background: bg009alt
 mapIcon: icone
 music:
-  download: https://nikkums.io/cswt/BGM/RainbowRoadWii.music.zip
+  download: 
+    - https://nikkums.io/cswt/BGM/RainbowRoadWii.music.zip
   map: mk7moon.40
   stock: wifimedley
   ventureCards: chainchomp

--- a/_maps/TurtleFortress/TurtleFortress.yaml
+++ b/_maps/TurtleFortress/TurtleFortress.yaml
@@ -14,10 +14,10 @@ frbFile1: TurtleFortress
 background: bg005
 mapIcon: TurtleFort
 music:
-  download: https://nikkums.io/cswt/BGM/TurtleFortress.Music.zip
+  download: 
+    - https://nikkums.io/cswt/BGM/TurtleFortress.music.zip
   map: TurtleFortress.50
   targetMet: TurtleTarget.50
-  bankruptcy:
 tourMode:
   bankruptcyLimit: 1
   opponent1: Yoshi


### PR DESCRIPTION
This PR fixes the yaml formatting issues around music download links in the most recent boards. I do not know why this is required, but for now it seems to be.