### PR TITLE
Update website to support downloads for maps with > 4 states

### DIFF
--- a/_includes/renderMapDownloadScript.liquid
+++ b/_includes/renderMapDownloadScript.liquid
@@ -26,11 +26,8 @@ Renders:
   {%- endif -%}
 {%- endcapture %}
 
-
 {% assign frbList = frbFiles | split: "," %}
 {% assign url_base = "https://raw.githubusercontent.com/FortuneStreetModding/fortunestreetmodding.github.io/main/" %}
-
-{% echo frbList %}
 
 {%- capture urls -%}
   {{- url_base | prepend: "'" | append: include.map.path | append: "'" -}}-

--- a/_includes/renderMapDownloadScript.liquid
+++ b/_includes/renderMapDownloadScript.liquid
@@ -28,20 +28,14 @@ Renders:
 
 {% assign frbList = frbFiles | split: "," %}
 {% assign url_base = "https://raw.githubusercontent.com/FortuneStreetModding/fortunestreetmodding.github.io/main/" %}
+{% assign frb_url_base = url_base | prepend: ",'" | append: gd_directory_path | append: "/" %}
 
 saveZip('{{ gd_directory_name }}', [
   {{- url_base | prepend: "'" | append: include.map.path | append: "'" -}}
-  {{- url_base | prepend: ",'" | append: gd_directory_path | append: "/" | append: include.map.frbFile1 | append: ".frb'" -}}
-  {%- if include.map.frbFile2 -%}
-  {{- url_base | prepend: ",'" | append: gd_directory_path | append: "/" | append: include.map.frbFile2 | append: ".frb'" -}}
-  {%- endif -%}
-  {%- if include.map.frbFile3 -%}
-  {{- url_base | prepend: ",'" | append: gd_directory_path | append: "/" | append: include.map.frbFile3 | append: ".frb'" -}}
-  {%- endif -%}
-  {%- if include.map.frbFile4 -%}
-  {{- url_base | prepend: ",'" | append: gd_directory_path | append: "/" | append: include.map.frbFile4 | append: ".frb'" -}}
-  {%- endif -%}
   {%- if include.map.mapIcon -%}
   {{- url_base | prepend: ",'" | append: gd_directory_path | append: "/" | append: include.map.mapIcon | append: ".png'" -}}
   {%- endif -%}
+  {% for frb in frbList -%}
+    {{- frb_url_base | append: frb | append: ".frb'" -}}
+  {% endfor -%}
   ]);

--- a/_includes/renderMapDownloadScript.liquid
+++ b/_includes/renderMapDownloadScript.liquid
@@ -29,14 +29,19 @@ Renders:
 {% assign frbList = frbFiles | split: "," %}
 {% assign url_base = "https://raw.githubusercontent.com/FortuneStreetModding/fortunestreetmodding.github.io/main/" %}
 
-{%- capture urls -%}
-  {{- url_base | prepend: "'" | append: include.map.path | append: "'" -}}-
-  {% for frb in frbList %}
-    {{- url_base | prepend: ",'" | append: gd_directory_path | append: "/" | append: frb | append: ".frb'" -}}
-  {% endfor %}
-  {%- if include.map.mapIcon -%}
-    {{- url_base | prepend: ",'" | append: gd_directory_path | append: "/" | append: include.map.mapIcon | append: ".png'" -}}
+saveZip('{{ gd_directory_name }}', [
+  {{- url_base | prepend: "'" | append: include.map.path | append: "'" -}}
+  {{- url_base | prepend: ",'" | append: gd_directory_path | append: "/" | append: include.map.frbFile1 | append: ".frb'" -}}
+  {%- if include.map.frbFile2 -%}
+  {{- url_base | prepend: ",'" | append: gd_directory_path | append: "/" | append: include.map.frbFile2 | append: ".frb'" -}}
   {%- endif -%}
-{%- endcapture %}
-
-saveZip('{{ gd_directory_name }}', {{ urls }});
+  {%- if include.map.frbFile3 -%}
+  {{- url_base | prepend: ",'" | append: gd_directory_path | append: "/" | append: include.map.frbFile3 | append: ".frb'" -}}
+  {%- endif -%}
+  {%- if include.map.frbFile4 -%}
+  {{- url_base | prepend: ",'" | append: gd_directory_path | append: "/" | append: include.map.frbFile4 | append: ".frb'" -}}
+  {%- endif -%}
+  {%- if include.map.mapIcon -%}
+  {{- url_base | prepend: ",'" | append: gd_directory_path | append: "/" | append: include.map.mapIcon | append: ".png'" -}}
+  {%- endif -%}
+  ]);

--- a/_includes/renderMapDownloadScript.liquid
+++ b/_includes/renderMapDownloadScript.liquid
@@ -27,8 +27,10 @@ Renders:
 {%- endcapture %}
 
 
-{% assign frbList = frbFiles | split: ", " %}
+{% assign frbList = frbFiles | split: "," %}
 {% assign url_base = "https://raw.githubusercontent.com/FortuneStreetModding/fortunestreetmodding.github.io/main/" %}
+
+{% echo frbList %}
 
 {%- capture urls -%}
   {{- url_base | prepend: "'" | append: include.map.path | append: "'" -}}-
@@ -39,5 +41,7 @@ Renders:
     {{- url_base | prepend: ",'" | append: gd_directory_path | append: "/" | append: include.map.mapIcon | append: ".png'" -}}
   {%- endif -%}
 {%- endcapture %}
+
+{% echo urls %}
 
 saveZip('{{ gd_directory_name }}', {{ urls }});

--- a/_includes/renderMapDownloadScript.liquid
+++ b/_includes/renderMapDownloadScript.liquid
@@ -11,7 +11,6 @@ Renders:
 {%- endcomment -%}
 {%- include getParent.liquid file_path=include.map.path -%}
 
-
 {%- capture frbFiles -%}
   {%- if include.map.frbFile4 -%}
       {{ include.map.frbFile1 }},{{include.map.frbFile2}},{{include.map.frbFile3}},{{include.map.frbFile4}}
@@ -27,13 +26,13 @@ Renders:
 {%- endcapture %}
 
 {% assign frbList = frbFiles | split: "," %}
-{% assign url_base = "https://raw.githubusercontent.com/FortuneStreetModding/fortunestreetmodding.github.io/main/" %}
-{% assign frb_url_base = url_base | prepend: ",'" | append: gd_directory_path | append: "/" %}
+{% assign url = "https://raw.githubusercontent.com/FortuneStreetModding/fortunestreetmodding.github.io/main/" %}
+{% assign frb_url_base = url | prepend: ",'" | append: gd_directory_path | append: "/" %}
 
 saveZip('{{ gd_directory_name }}', [
-  {{- url_base | prepend: "'" | append: include.map.path | append: "'" -}}
+  {{- url | prepend: "'" | append: include.map.path | append: "'" -}}
   {%- if include.map.mapIcon -%}
-  {{- url_base | prepend: ",'" | append: gd_directory_path | append: "/" | append: include.map.mapIcon | append: ".png'" -}}
+  {{- url | prepend: ",'" | append: gd_directory_path | append: "/" | append: include.map.mapIcon | append: ".png'" -}}
   {%- endif -%}
   {% for frb in frbList -%}
     {{- frb_url_base | append: frb | append: ".frb'" -}}

--- a/_includes/renderMapDownloadScript.liquid
+++ b/_includes/renderMapDownloadScript.liquid
@@ -39,6 +39,4 @@ Renders:
   {%- endif -%}
 {%- endcapture %}
 
-{% echo urls %}
-
 saveZip('{{ gd_directory_name }}', {{ urls }});


### PR DESCRIPTION
If this worked previously, I don't know how it did. It was hardcoded for `frbFile1` through `4` as far as I can tell. This new implementation still supports those tags, but it also grabs `frbFiles` if none of those are present.